### PR TITLE
Fixes an error when using the Cray Compiler

### DIFF
--- a/field_summary.f90
+++ b/field_summary.f90
@@ -126,7 +126,6 @@ SUBROUTINE field_summary()
   IF(parallel%boss) THEN
     WRITE(g_out,'(a6,i7,7e16.4)')' step:',step,vol,mass,mass/vol,press/vol,ie,ke,ie+ke
     WRITE(g_out,*)
-  !$  ENDIF
   ENDIF
 
   !Check if this is the final call and if it is a test problem, check the result.


### PR DESCRIPTION
Apparently the removed code is complaint when OpenMP directives are used. The result is that there is an unmatched `ENDIF` statement.